### PR TITLE
Lower importance of BACKGROUND_WORK_CHANNEL_ID to None

### DIFF
--- a/app/src/main/java/uk/nhs/nhsx/covid19/android/app/notifications/NotificationProvider.kt
+++ b/app/src/main/java/uk/nhs/nhsx/covid19/android/app/notifications/NotificationProvider.kt
@@ -111,7 +111,7 @@ class NotificationProvider @Inject constructor(private val context: Context) {
         createNotificationChannel(
             channelId = BACKGROUND_WORK_CHANNEL_ID,
             channelNameResId = R.string.notification_channel_background_work_name,
-            importance = NotificationManagerCompat.IMPORTANCE_LOW,
+            importance = NotificationManagerCompat.IMPORTANCE_NONE,
             channelDescriptionResId = R.string.notification_channel_background_work_description
         )
     }


### PR DESCRIPTION
This lowers the notification importance for notifications in the BACKGROUND_WORK_CHANNEL_ID (such as getUpdatingDatabaseNotification) to None, this [should suppress](https://developer.android.com/reference/androidx/core/app/NotificationManagerCompat#IMPORTANCE_NONE) the notification from appearing on devices and closes #5